### PR TITLE
Static binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@
 
 cmds: vendor
 	for cmd in $$(ls cmd); do \
+		CGO_ENABLED=0 \
 		go build -o "$${cmd}" "./cmd/$${cmd}" || exit 1; \
 	done
 


### PR DESCRIPTION
This patch changes the build process so that it generates an static
binary that will run in any Linux variant.