### PR TITLE
Cluster command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,15 +26,21 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:bf36b3cd1c92da7363c1f3fca9d1c0fd6eb032c0ae5b32522ec8900000a94417"
+  digest = "1:29b1991538ec62371b388c2371da2816591f667332f48931e8f648daa3606a56"
   name = "github.com/openshift-online/uhc-sdk-go"
   packages = [
     "pkg/client",
+    "pkg/client/accountsmgmt",
+    "pkg/client/accountsmgmt/v1",
+    "pkg/client/clustersmgmt",
+    "pkg/client/clustersmgmt/v1",
+    "pkg/client/errors",
+    "pkg/client/helpers",
     "pkg/client/internal",
   ]
   pruneopts = "UT"
-  revision = "bcd7eb34e17a374a442d43667f8a3747d92c0a05"
-  version = "v0.1.5"
+  revision = "9d1a1d3c76bae5025551e1bae9943cc65ee8c0ce"
+  version = "v0.1.7"
 
 [[projects]]
   digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
@@ -59,6 +65,7 @@
     "github.com/dgrijalva/jwt-go",
     "github.com/golang/glog",
     "github.com/openshift-online/uhc-sdk-go/pkg/client",
+    "github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/openshift-online/uhc-sdk-go"
-  version = "0.1.5"
+  version = "0.1.7"
 
 [[constraint]]
   name = "github.com/spf13/pflag"

--- a/cmd/uhc/cluster/cmd.go
+++ b/cmd/uhc/cluster/cmd.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/uhc-cli/cmd/uhc/cluster/describe"
+	"github.com/openshift-online/uhc-cli/cmd/uhc/cluster/list"
+	"github.com/openshift-online/uhc-cli/cmd/uhc/cluster/status"
+	"github.com/spf13/cobra"
+)
+
+var args struct {
+	debug bool
+}
+var Cmd = &cobra.Command{
+	Use:   "cluster COMMAND",
+	Short: "Get information about clusters",
+	Long:  "Get status or information about a single cluster, or a list of clusters",
+	Run:   run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.BoolVar(
+		&args.debug,
+		"debug",
+		false,
+		"Enable debug mode.",
+	)
+	Cmd.AddCommand(list.Cmd)
+	Cmd.AddCommand(status.Cmd)
+	Cmd.AddCommand(describe.Cmd)
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	// Check there is at least one argument
+	if len(argv) < 1 {
+		fmt.Fprintf(os.Stderr, "Expected at least one argument\n")
+		os.Exit(1)
+	}
+}

--- a/cmd/uhc/cluster/describe/describe.go
+++ b/cmd/uhc/cluster/describe/describe.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/uhc-cli/pkg/config"
+	"github.com/openshift-online/uhc-cli/pkg/util"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+
+	"github.com/spf13/cobra"
+)
+
+var args struct {
+	debug bool
+}
+
+var Cmd = &cobra.Command{
+	Use:   "describe CLUSTERID",
+	Short: "Decribe a cluster",
+	Long:  "Get info about a cluster identified by its cluster ID",
+	Run:   run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.BoolVar(
+		&args.debug,
+		"debug",
+		false,
+		"Enable debug mode.",
+	)
+}
+
+func run(cmd *cobra.Command, argv []string) {
+
+	if len(argv) != 1 {
+		fmt.Fprintf(os.Stderr, "Expected exactly one cluster\n")
+		os.Exit(1)
+	}
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't load config file: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		fmt.Fprintf(os.Stderr, "Not logged in, run the 'login' command\n")
+		os.Exit(1)
+	}
+
+	// Check that the configuration has credentials or tokens that haven't have expired:
+	armed, err := config.Armed(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
+		os.Exit(1)
+	}
+	if !armed {
+		fmt.Fprintf(os.Stderr, "Tokens have expired, run the 'login' command\n")
+		os.Exit(1)
+	}
+
+	// Create the connection:
+	logger, err := util.NewLogger(args.debug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the connection, and remember to close it:
+	connection, err := client.NewConnectionBuilder().
+		Logger(logger).
+		TokenURL(cfg.TokenURL).
+		Client(cfg.ClientID, cfg.ClientSecret).
+		Scopes(cfg.Scopes...).
+		URL(cfg.URL).
+		User(cfg.User, cfg.Password).
+		Tokens(cfg.AccessToken, cfg.RefreshToken).
+		Insecure(cfg.Insecure).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	resource := connection.ClustersMgmt().V1().Clusters()
+
+	// Get the resource that manages the cluster that we want to display:
+	clusterResource := resource.Cluster(argv[0])
+
+	// Retrieve the collection of clusters:
+	response, err := clusterResource.Get().
+		Send()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve clusters: %s", err)
+		os.Exit(1)
+	}
+
+	cluster := response.Body()
+	fmt.Printf("ID:       %s\n"+
+		"Name:     %s.%s\n"+
+		"Masters:  %d\n"+
+		"Computes: %d\n"+
+		"Region:   %s\n"+
+		"Multi-az: %t\n",
+		cluster.ID(),
+		cluster.Name(),
+		cluster.DNS().BaseDomain(),
+		cluster.Nodes().Master(),
+		cluster.Nodes().Compute(),
+		cluster.Region().ID(),
+		cluster.MultiAZ(),
+	)
+}

--- a/cmd/uhc/cluster/list/list.go
+++ b/cmd/uhc/cluster/list/list.go
@@ -1,0 +1,184 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openshift-online/uhc-cli/pkg/config"
+	"github.com/openshift-online/uhc-cli/pkg/util"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+)
+
+var args struct {
+	parameter []string
+	debug     bool
+	managed   bool
+}
+
+var managed bool
+
+var Cmd = &cobra.Command{
+	Use:   "list [flags] ",
+	Short: "List clusters",
+	Long:  "List clusters by ID and Name",
+	Run:   run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.BoolVar(
+		&args.debug,
+		"debug",
+		false,
+		"Enable debug mode.",
+	)
+	flags.StringArrayVar(
+		&args.parameter,
+		"parameter",
+		nil,
+		"Query parameters to add to the request. The value must be the name of the "+
+			"parameter, followed by an optional equals sign and then the value "+
+			"of the parameter. Can be used multiple times to specify multiple "+
+			"parameters or multiple values for the same parameter.",
+	)
+	flags.BoolVar(
+		&args.managed,
+		"managed",
+		false,
+		"Filter managed/unmanaged clusters",
+	)
+}
+
+func run(cmd *cobra.Command, argv []string) {
+
+	pageSize := 100
+	pageIndex := 1
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't load config file: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		fmt.Fprintf(os.Stderr, "Not logged in, run the 'login' command\n")
+		os.Exit(1)
+	}
+
+	// Check that the configuration has credentials or tokens that haven't have expired:
+	armed, err := config.Armed(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
+		os.Exit(1)
+	}
+	if !armed {
+		fmt.Fprintf(os.Stderr, "Tokens have expired, run the 'login' command\n")
+		os.Exit(1)
+	}
+
+	// Create the connection:
+	logger, err := util.NewLogger(args.debug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the connection, and remember to close it:
+	connection, err := client.NewConnectionBuilder().
+		Logger(logger).
+		TokenURL(cfg.TokenURL).
+		Client(cfg.ClientID, cfg.ClientSecret).
+		Scopes(cfg.Scopes...).
+		URL(cfg.URL).
+		User(cfg.User, cfg.Password).
+		Tokens(cfg.AccessToken, cfg.RefreshToken).
+		Insecure(cfg.Insecure).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	collection := connection.ClustersMgmt().V1().Clusters()
+
+	if cmd.Flags().Changed("managed") {
+		managed = args.managed
+	} else {
+		managed = false
+	}
+
+	for {
+		// Fetch the next page:
+		response := getResponse(collection, managed, args.parameter, pageSize, pageIndex)
+
+		// Display the fetched page:
+		response.Items().Each(func(cluster *v1.Cluster) bool {
+			fmt.Printf("ID: %s - Name: %s.%s\n", cluster.ID(), cluster.Name(), cluster.DNS().BaseDomain())
+			return true
+		})
+		// If the number of fetched results is less than requested, then
+		// this was the last page, otherwise process the next one:
+		if response.Size() < pageSize {
+			break
+		}
+		pageIndex++
+	}
+}
+
+func getResponse(collection *v1.ClustersClient,
+	managed bool,
+	parameter []string,
+	pageSize int,
+	pageIndex int) *v1.ClustersListResponse {
+
+	listRequest := collection.List().
+		Size(pageSize).
+		Page(pageIndex)
+
+	if managed {
+		listRequest.Search("managed='true'")
+	} else if len(parameter) > 0 {
+		for _, parameter := range args.parameter {
+			var name string
+			var value string
+			position := strings.Index(parameter, "=")
+			if position != -1 {
+				name = parameter[:position]
+				value = parameter[position+1:]
+			} else {
+				name = parameter
+				value = ""
+			}
+			listRequest.Parameter(name, value)
+		}
+	}
+
+	response, err := listRequest.Send()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve clusters: %s", err)
+		os.Exit(1)
+	}
+
+	return response
+}

--- a/cmd/uhc/cluster/status/status.go
+++ b/cmd/uhc/cluster/status/status.go
@@ -1,0 +1,131 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/uhc-cli/pkg/config"
+	"github.com/openshift-online/uhc-cli/pkg/util"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+var args struct {
+	debug bool
+}
+
+var Cmd = &cobra.Command{
+	Use:   "status CLUSTERID",
+	Short: "Status of a cluster",
+	Long:  "Get the status of a cluster identified by its cluster ID",
+	Run:   run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.BoolVar(
+		&args.debug,
+		"debug",
+		false,
+		"Enable debug mode.",
+	)
+}
+func run(cmd *cobra.Command, argv []string) {
+
+	if len(argv) != 1 {
+		fmt.Fprintf(os.Stderr, "Expected exactly one cluster\n")
+		os.Exit(1)
+	}
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't load config file: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		fmt.Fprintf(os.Stderr, "Not logged in, run the 'login' command\n")
+		os.Exit(1)
+	}
+
+	// Check that the configuration has credentials or tokens that haven't have expired:
+	armed, err := config.Armed(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
+		os.Exit(1)
+	}
+	if !armed {
+		fmt.Fprintf(os.Stderr, "Tokens have expired, run the 'login' command\n")
+		os.Exit(1)
+	}
+
+	// Create the connection:
+	logger, err := util.NewLogger(args.debug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the connection, and remember to close it:
+	connection, err := client.NewConnectionBuilder().
+		Logger(logger).
+		TokenURL(cfg.TokenURL).
+		Client(cfg.ClientID, cfg.ClientSecret).
+		Scopes(cfg.Scopes...).
+		URL(cfg.URL).
+		User(cfg.User, cfg.Password).
+		Tokens(cfg.AccessToken, cfg.RefreshToken).
+		Insecure(cfg.Insecure).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	resource := connection.ClustersMgmt().V1().Clusters()
+
+	// Get the resource that manages the cluster that we want to display:
+	clusterResource := resource.Cluster(argv[0])
+
+	// Retrieve the collection of clusters:
+	response, err := clusterResource.Get().
+		Send()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve clusters: %s", err)
+		os.Exit(1)
+	}
+
+	cluster := response.Body()
+
+	//Get data out of the response
+	clusterMemory := cluster.Memory()
+	clusterCPU := cluster.CPU()
+	memUsed := clusterMemory.Used().Value() / 1000000000
+	memTotal := clusterMemory.Total().Value() / 1000000000
+
+	fmt.Printf("State:   %s\n"+
+		"Memory:  %.2f/%.2f used\n"+
+		"CPU:     %.2f/%.2f used\n",
+		cluster.State(),
+		memUsed, memTotal,
+		clusterCPU.Used().Value(), clusterCPU.Total().Value(),
+	)
+}

--- a/cmd/uhc/main.go
+++ b/cmd/uhc/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/openshift-online/uhc-cli/cmd/uhc/cluster"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/delete"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/get"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/login"
@@ -61,6 +62,7 @@ func init() {
 	root.AddCommand(post.Cmd)
 	root.AddCommand(token.Cmd)
 	root.AddCommand(version.Cmd)
+	root.AddCommand(cluster.Cmd)
 }
 
 func main() {


### PR DESCRIPTION
This PR creates a `uhc cluster` command to better interact with clusters directly through the api.

Sub commands:

- [x]  list
- [x] status
- [x] describe