### PR TITLE
Release 0.1.10

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the
 `uhc` command line tool.
 
+== 0.1.10 May 3 2019
+
+- Adapt to changes in the API and SDK that moved cluster basic metrics to a new
+  `metrics` attribute.
+
 == 0.1.9 May 2 2019
 
 - Added the `cluster` command.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:29b1991538ec62371b388c2371da2816591f667332f48931e8f648daa3606a56"
+  digest = "1:9b85c9d2be244ed78f787e75c8dca7c69b1a48265062e42e0f403e221ba24759"
   name = "github.com/openshift-online/uhc-sdk-go"
   packages = [
     "pkg/client",
@@ -39,8 +39,8 @@
     "pkg/client/internal",
   ]
   pruneopts = "UT"
-  revision = "9d1a1d3c76bae5025551e1bae9943cc65ee8c0ce"
-  version = "v0.1.7"
+  revision = "cddd0f41f9a1605bbc9e64ec36da8c89baea7cd8"
+  version = "v0.1.8"
 
 [[projects]]
   digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/openshift-online/uhc-sdk-go"
-  version = "0.1.7"
+  version = "0.1.8"
 
 [[constraint]]
   name = "github.com/spf13/pflag"

--- a/cmd/uhc/cluster/status/status.go
+++ b/cmd/uhc/cluster/status/status.go
@@ -116,8 +116,8 @@ func run(cmd *cobra.Command, argv []string) {
 	cluster := response.Body()
 
 	//Get data out of the response
-	clusterMemory := cluster.Memory()
-	clusterCPU := cluster.CPU()
+	clusterMemory := cluster.Metrics().Memory()
+	clusterCPU := cluster.Metrics().CPU()
 	memUsed := clusterMemory.Used().Value() / 1000000000
 	memTotal := clusterMemory.Total().Value() / 1000000000
 

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.9"
+const Version = "0.1.10"


### PR DESCRIPTION
The more relevant changes in this new version are the following:

- Adapt to changes in the API and SDK that moved cluster basic metrics to a new
  `metrics` attribute.
