### PR TITLE
Release 0.1.11

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 `uhc` command line tool.
 
+== 0.1.11 May 8 2019
+
+- Added the `completion` command that generates _bash_ completion scripts.
+
 == 0.1.10 May 3 2019
 
 - Adapt to changes in the API and SDK that moved cluster basic metrics to a new

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.10"
+const Version = "0.1.11"


### PR DESCRIPTION
The more relevant changes in this new version are the following:

- Added the `completion` command that generates _bash_ completion
  scripts.