### PR TITLE
Remove all the cruft

### DIFF
--- a/cmd/uhc/common/args.go
+++ b/cmd/uhc/common/args.go
@@ -1,0 +1,8 @@
+package common
+
+type Args struct {
+	Debug     bool
+	Parameter []string
+	Header    []string
+	Body      string
+}

--- a/cmd/uhc/common/flags.go
+++ b/cmd/uhc/common/flags.go
@@ -1,0 +1,30 @@
+package common
+
+import "github.com/spf13/pflag"
+
+func AddCommonFlags(flags *pflag.FlagSet, args *Args) {
+	flags.BoolVar(
+		&args.Debug,
+		"debug",
+		false,
+		"Enable debug mode.",
+	)
+	flags.StringArrayVar(
+		&args.Parameter,
+		"parameter",
+		nil,
+		"Query parameters to add to the request. The value must be the name of the "+
+			"parameter, followed by an optional equals sign and then the value "+
+			"of the parameter. Can be used multiple times to specify multiple "+
+			"parameters or multiple values for the same parameter.",
+	)
+	flags.StringArrayVar(
+		&args.Header,
+		"header",
+		nil,
+		"Headers to add to the request. The value must be the name of the header "+
+			"followed by an optional equals sign and then the value of the "+
+			"header. Can be used multiple times to specify multiple headers "+
+			"or multiple values for the same header.",
+	)
+}

--- a/cmd/uhc/delete/cmd.go
+++ b/cmd/uhc/delete/cmd.go
@@ -19,22 +19,15 @@ package delete
 import (
 	"fmt"
 	"os"
-	"strings"
 
+	"github.com/openshift-online/uhc-cli/cmd/uhc/common"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/urls"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-cli/pkg/dump"
 	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
-var args struct {
-	debug     bool
-	parameter []string
-	header    []string
-}
+var args common.Args
 
 var Cmd = &cobra.Command{
 	Use:   "delete PATH",
@@ -45,30 +38,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
-	flags.StringArrayVar(
-		&args.parameter,
-		"parameter",
-		nil,
-		"Query parameters to add to the request. The value must be the name of the "+
-			"parameter, followed by an optional equals sign and then the value "+
-			"of the parameter. Can be used multiple times to specify multiple "+
-			"parameters or multiple values for the same parameter.",
-	)
-	flags.StringArrayVar(
-		&args.header,
-		"header",
-		nil,
-		"Headers to add to the request. The value must be the name of the header "+
-			"followed by an optional equals sign and then the value of the "+
-			"header. Can be used multiple times to specify multiple headers "+
-			"or multiple values for the same header.",
-	)
+	common.AddCommonFlags(flags, &args)
 }
 
 func run(cmd *cobra.Command, argv []string) {
@@ -78,112 +48,13 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't load config file: %v\n", err)
-		os.Exit(1)
-	}
-	if cfg == nil {
-		fmt.Fprintf(os.Stderr, "Not logged in, run the 'login' command\n")
-		os.Exit(1)
-	}
-
-	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
-		os.Exit(1)
-	}
-	if !armed {
-		fmt.Fprintf(os.Stderr, "Tokens have expired, run the 'login' command\n")
-		os.Exit(1)
-	}
-
-	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := util.NewConnection(args.Debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Create and populate the request:
 	request := connection.Delete().Path(path)
-	for _, parameter := range args.parameter {
-		var name string
-		var value string
-		position := strings.Index(parameter, "=")
-		if position != -1 {
-			name = parameter[:position]
-			value = parameter[position+1:]
-		} else {
-			name = parameter
-			value = ""
-		}
-		request.Parameter(name, value)
-	}
-	for _, header := range args.header {
-		var name string
-		var value string
-		position := strings.Index(header, "=")
-		if position != -1 {
-			name = header[:position]
-			value = header[position+1:]
-		} else {
-			name = header
-			value = ""
-		}
-		request.Header(name, value)
-	}
-
-	// Send the request:
-	response, err := request.Send()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't send request: %v\n", err)
-		os.Exit(1)
-	}
-	status := response.Status()
-	body := response.Bytes()
-	if status < 400 {
-		err = dump.Pretty(os.Stdout, body)
-	} else {
-		err = dump.Pretty(os.Stderr, body)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't print body: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Save the configuration:
-	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't get tokens: %v\n", err)
-		os.Exit(1)
-	}
-	err = config.Save(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't save config file: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Bye:
-	if status < 400 {
-		os.Exit(0)
-	} else {
-		os.Exit(1)
-	}
+	util.AddParamsAndHeaders(request, args.Parameter, args.Header)
+	util.DoHTTP(request)
 }

--- a/cmd/uhc/get/cmd.go
+++ b/cmd/uhc/get/cmd.go
@@ -19,22 +19,15 @@ package get
 import (
 	"fmt"
 	"os"
-	"strings"
 
+	"github.com/openshift-online/uhc-cli/cmd/uhc/common"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/urls"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-cli/pkg/dump"
 	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
-var args struct {
-	debug     bool
-	parameter []string
-	header    []string
-}
+var args common.Args
 
 var Cmd = &cobra.Command{
 	Use:   "get RESOURCE {ID}",
@@ -45,30 +38,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
-	flags.StringArrayVar(
-		&args.parameter,
-		"parameter",
-		nil,
-		"Query parameters to add to the request. The value must be the name of the "+
-			"parameter, followed by an optional equals sign and then the value "+
-			"of the parameter. Can be used multiple times to specify multiple "+
-			"parameters or multiple values for the same parameter.",
-	)
-	flags.StringArrayVar(
-		&args.header,
-		"header",
-		nil,
-		"Headers to add to the request. The value must be the name of the header "+
-			"followed by an optional equals sign and then the value of the "+
-			"header. Can be used multiple times to specify multiple headers "+
-			"or multiple values for the same header.",
-	)
+	common.AddCommonFlags(flags, &args)
 }
 
 func run(cmd *cobra.Command, argv []string) {
@@ -78,44 +48,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't load config file: %v\n", err)
-		os.Exit(1)
-	}
-	if cfg == nil {
-		fmt.Fprintf(os.Stderr, "Not logged in, run the 'login' command\n")
-		os.Exit(1)
-	}
-
-	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
-		os.Exit(1)
-	}
-	if !armed {
-		fmt.Fprintf(os.Stderr, "Tokens have expired, run the 'login' command\n")
-		os.Exit(1)
-	}
-
-	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := util.NewConnection(args.Debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)
@@ -123,67 +56,6 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Create and populate the request:
 	request := connection.Get().Path(path)
-	for _, parameter := range args.parameter {
-		var name string
-		var value string
-		position := strings.Index(parameter, "=")
-		if position != -1 {
-			name = parameter[:position]
-			value = parameter[position+1:]
-		} else {
-			name = parameter
-			value = ""
-		}
-		request.Parameter(name, value)
-	}
-	for _, header := range args.header {
-		var name string
-		var value string
-		position := strings.Index(header, "=")
-		if position != -1 {
-			name = header[:position]
-			value = header[position+1:]
-		} else {
-			name = header
-			value = ""
-		}
-		request.Header(name, value)
-	}
-
-	// Send the request:
-	response, err := request.Send()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't send request: %v\n", err)
-		os.Exit(1)
-	}
-	status := response.Status()
-	body := response.Bytes()
-	if status < 400 {
-		err = dump.Pretty(os.Stdout, body)
-	} else {
-		err = dump.Pretty(os.Stderr, body)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't print body: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Save the configuration:
-	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't get tokens: %v\n", err)
-		os.Exit(1)
-	}
-	err = config.Save(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't save config file: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Bye:
-	if status < 400 {
-		os.Exit(0)
-	} else {
-		os.Exit(1)
-	}
+	util.AddParamsAndHeaders(request, args.Parameter, args.Header)
+	util.DoHTTP(request)
 }

--- a/cmd/uhc/patch/cmd.go
+++ b/cmd/uhc/patch/cmd.go
@@ -18,25 +18,16 @@ package patch
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"strings"
 
+	"github.com/openshift-online/uhc-cli/cmd/uhc/common"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/urls"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-cli/pkg/dump"
 	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
-var args struct {
-	debug     bool
-	parameter []string
-	header    []string
-	body      string
-}
+var args common.Args
 
 var Cmd = &cobra.Command{
 	Use:   "patch PATH",
@@ -47,32 +38,9 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
-	flags.StringArrayVar(
-		&args.parameter,
-		"parameter",
-		nil,
-		"Query parameters to add to the request. The value must be the name of the "+
-			"parameter, followed by an optional equals sign and then the value "+
-			"of the parameter. Can be used multiple times to specify multiple "+
-			"parameters or multiple values for the same parameter.",
-	)
-	flags.StringArrayVar(
-		&args.header,
-		"header",
-		nil,
-		"Headers to add to the request. The value must be the name of the header "+
-			"followed by an optional equals sign and then the value of the "+
-			"header. Can be used multiple times to specify multiple headers "+
-			"or multiple values for the same header.",
-	)
+	common.AddCommonFlags(flags, &args)
 	flags.StringVar(
-		&args.body,
+		&args.Body,
 		"body",
 		"",
 		"Name fo the file containing the request body. If this isn't given then "+
@@ -86,45 +54,7 @@ func run(cmd *cobra.Command, argv []string) {
 		fmt.Fprintf(os.Stderr, "Could not create URI: %v\n", err)
 		os.Exit(1)
 	}
-
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't load config file: %v\n", err)
-		os.Exit(1)
-	}
-	if cfg == nil {
-		fmt.Fprintf(os.Stderr, "Not logged in, run the 'login' command\n")
-		os.Exit(1)
-	}
-
-	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
-		os.Exit(1)
-	}
-	if !armed {
-		fmt.Fprintf(os.Stderr, "Tokens have expired, run the 'login' command\n")
-		os.Exit(1)
-	}
-
-	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := util.NewConnection(args.Debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)
@@ -132,78 +62,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Create and populate the request:
 	request := connection.Patch().Path(path)
-	for _, parameter := range args.parameter {
-		var name string
-		var value string
-		position := strings.Index(parameter, "=")
-		if position != -1 {
-			name = parameter[:position]
-			value = parameter[position+1:]
-		} else {
-			name = parameter
-			value = ""
-		}
-		request.Parameter(name, value)
-	}
-	for _, header := range args.header {
-		var name string
-		var value string
-		position := strings.Index(header, "=")
-		if position != -1 {
-			name = header[:position]
-			value = header[position+1:]
-		} else {
-			name = header
-			value = ""
-		}
-		request.Header(name, value)
-	}
-	var body []byte
-	if args.body != "" {
-		body, err = ioutil.ReadFile(args.body)
-	} else {
-		body, err = ioutil.ReadAll(os.Stdin)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't read body: %v\n", err)
-		os.Exit(1)
-	}
-	request.Bytes(body)
-
-	// Send the request:
-	response, err := request.Send()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't send request: %v\n", err)
-		os.Exit(1)
-	}
-	status := response.Status()
-	body = response.Bytes()
-	if status < 400 {
-		err = dump.Pretty(os.Stdout, body)
-	} else {
-		err = dump.Pretty(os.Stderr, body)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't print body: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Save the configuration:
-	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't get tokens: %v\n", err)
-		os.Exit(1)
-	}
-	err = config.Save(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't save config file: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Bye:
-	if status < 400 {
-		os.Exit(0)
-	} else {
-		os.Exit(1)
-	}
+	util.AddParamsAndHeaders(request, args.Parameter, args.Header)
+	util.AddBody(request, args.Body)
+	util.DoHTTP(request)
 }

--- a/cmd/uhc/post/cmd.go
+++ b/cmd/uhc/post/cmd.go
@@ -18,25 +18,16 @@ package post
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"strings"
 
+	"github.com/openshift-online/uhc-cli/cmd/uhc/common"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/urls"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-cli/pkg/dump"
 	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
-var args struct {
-	debug     bool
-	parameter []string
-	header    []string
-	body      string
-}
+var args common.Args
 
 var Cmd = &cobra.Command{
 	Use:   "post PATH",
@@ -47,32 +38,9 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
-	flags.StringSliceVar(
-		&args.parameter,
-		"parameter",
-		nil,
-		"Query parameters to add to the request. The value must be the name of the "+
-			"parameter, followed by an optional equals sign and then the value "+
-			"of the parameter. Can be used multiple times to specify multiple "+
-			"parameters or multiple values for the same parameter.",
-	)
-	flags.StringSliceVar(
-		&args.header,
-		"header",
-		nil,
-		"Headers to add to the request. The value must be the name of the header "+
-			"followed by an optional equals sign and then the value of the "+
-			"header. Can be used multiple times to specify multiple headers "+
-			"or multiple values for the same header.",
-	)
+	common.AddCommonFlags(flags, &args)
 	flags.StringVar(
-		&args.body,
+		&args.Body,
 		"body",
 		"",
 		"Name fo the file containing the request body. If this isn't given then "+
@@ -87,123 +55,14 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't load config file: %v\n", err)
-		os.Exit(1)
-	}
-	if cfg == nil {
-		fmt.Fprintf(os.Stderr, "Not logged in, run the 'login' command\n")
-		os.Exit(1)
-	}
-
-	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
-		os.Exit(1)
-	}
-	if !armed {
-		fmt.Fprintf(os.Stderr, "Tokens have expired, run the 'login' command\n")
-		os.Exit(1)
-	}
-
-	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := util.NewConnection(args.Debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Create and populate the request:
 	request := connection.Post().Path(path)
-	for _, parameter := range args.parameter {
-		var name string
-		var value string
-		position := strings.Index(parameter, "=")
-		if position != -1 {
-			name = parameter[:position]
-			value = parameter[position+1:]
-		} else {
-			name = parameter
-			value = ""
-		}
-		request.Parameter(name, value)
-	}
-	for _, header := range args.header {
-		var name string
-		var value string
-		position := strings.Index(header, "=")
-		if position != -1 {
-			name = header[:position]
-			value = header[position+1:]
-		} else {
-			name = header
-			value = ""
-		}
-		request.Header(name, value)
-	}
-	var body []byte
-	if args.body != "" {
-		body, err = ioutil.ReadFile(args.body)
-	} else {
-		body, err = ioutil.ReadAll(os.Stdin)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't read body: %v\n", err)
-		os.Exit(1)
-	}
-	request.Bytes(body)
-
-	// Send the request:
-	response, err := request.Send()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't send request: %v\n", err)
-		os.Exit(1)
-	}
-	status := response.Status()
-	body = response.Bytes()
-	if status < 400 {
-		err = dump.Pretty(os.Stdout, body)
-	} else {
-		err = dump.Pretty(os.Stderr, body)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't print body: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Save the configuration:
-	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't get tokens: %v\n", err)
-		os.Exit(1)
-	}
-	err = config.Save(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't save config file: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Bye:
-	if status < 400 {
-		os.Exit(0)
-	} else {
-		os.Exit(1)
-	}
+	util.AddParamsAndHeaders(request, args.Parameter, args.Header)
+	util.AddBody(request, args.Body)
+	util.DoHTTP(request)
 }

--- a/pkg/util/connection.go
+++ b/pkg/util/connection.go
@@ -1,0 +1,136 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/openshift-online/uhc-cli/pkg/config"
+	"github.com/openshift-online/uhc-cli/pkg/dump"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+)
+
+func NewConnection(debug bool) (*client.Connection, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("Can't load config file: %v\n", err)
+	}
+	if cfg == nil {
+		fmt.Fprintf(os.Stderr, "Not logged in, run the 'login' command\n")
+		os.Exit(1)
+	}
+
+	// Check that the configuration has credentials or tokens that don't have expired:
+	armed, err := config.Armed(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
+		os.Exit(1)
+	}
+	if !armed {
+		fmt.Fprintf(os.Stderr, "Tokens have expired, run the 'login' command\n")
+		os.Exit(1)
+	}
+
+	// Create the connection:
+	logger, err := NewLogger(debug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
+		os.Exit(1)
+	}
+	connection, err := client.NewConnectionBuilder().
+		Logger(logger).
+		TokenURL(cfg.TokenURL).
+		Client(cfg.ClientID, cfg.ClientSecret).
+		Scopes(cfg.Scopes...).
+		URL(cfg.URL).
+		User(cfg.User, cfg.Password).
+		Tokens(cfg.AccessToken, cfg.RefreshToken).
+		Insecure(cfg.Insecure).
+		Build()
+
+	// Save the configuration:
+	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't get tokens: %v\n", err)
+		os.Exit(1)
+	}
+	err = config.Save(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't save config file: %v\n", err)
+		os.Exit(1)
+	}
+
+	return connection, nil
+}
+
+func AddBody(request *client.Request, body string) {
+	var bytes []byte
+	var err error
+	if body != "" {
+		bytes, err = ioutil.ReadFile(body)
+	} else {
+		bytes, err = ioutil.ReadAll(os.Stdin)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't read body: %v\n", err)
+		os.Exit(1)
+	}
+	request.Bytes(bytes)
+}
+
+func AddParamsAndHeaders(request *client.Request, parameters, headers []string) {
+	for _, parameter := range parameters {
+		var name string
+		var value string
+		position := strings.Index(parameter, "=")
+		if position != -1 {
+			name = parameter[:position]
+			value = parameter[position+1:]
+		} else {
+			name = parameter
+			value = ""
+		}
+		request.Parameter(name, value)
+	}
+	for _, header := range headers {
+		var name string
+		var value string
+		position := strings.Index(header, "=")
+		if position != -1 {
+			name = header[:position]
+			value = header[position+1:]
+		} else {
+			name = header
+			value = ""
+		}
+		request.Header(name, value)
+	}
+}
+
+func DoHTTP(request *client.Request) {
+	// Send the request:
+	response, err := request.Send()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't send request: %v\n", err)
+		os.Exit(1)
+	}
+	status := response.Status()
+	body := response.Bytes()
+	if status < 400 {
+		err = dump.Pretty(os.Stdout, body)
+	} else {
+		err = dump.Pretty(os.Stderr, body)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't print body: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Bye:
+	if status < 400 {
+		os.Exit(0)
+	} else {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Each HTTP subcommand is cut and pasted boilerplate and cruft.  Removing the duplication requires use of common `util` functions.  I'd rather change the packaging, though, so that each subcommand is packaged together to allow for a framework to handle the cruft.  A smart framework can perform all the same functions while allowing override for some things as needed (so far, nothing looks like it actually needs it).

