### PR TITLE
Fix deprecated issuer

### DIFF
--- a/cmd/uhc/login/cmd.go
+++ b/cmd/uhc/login/cmd.go
@@ -43,7 +43,7 @@ const (
 	// #nosec G101
 	deprecatedTokenURL = "https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/token"
 	deprecatedClientID = "uhc"
-	deprecatedIssuer   = "sso.redhat.com"
+	deprecatedIssuer   = "developers.redhat.com"
 )
 
 var args struct {


### PR DESCRIPTION
This patch fixes the name of the deprecated issuer: it should be
_developers.redhat.com_ and not _sso.redhat.com_.