### PR TITLE
Release 0.1.16

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the
 `uhc` command line tool.
 
+== 0.1.16 Jun 28 2019
+
+- Fix deprecated issuer: should be _developers.redhat.com_ instead of
+  _sso.redhat.com_.
+
 == 0.1.15 Jun 27 2019
 
 - Added the `--single` option to the `get` command to format the output in one

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,7 +144,7 @@
   revision = "v1.5.0"
 
 [[projects]]
-  digest = "1:7f3690ce8f406684fc85b958cb5e483a19618374406d0755922845e848eb35a1"
+  digest = "1:0f2403c00f8561333f7bebe2fd4a2ae1db02c9955ebdbf0a1440ac44be50bf03"
   name = "github.com/openshift-online/uhc-sdk-go"
   packages = [
     "pkg/client",
@@ -157,8 +157,8 @@
     "pkg/client/internal",
   ]
   pruneopts = "NUT"
-  revision = "92e97338dd0c3be5143c6324804e9ebc4eddf762"
-  version = "v0.1.22"
+  revision = "22fe296e1f1d57bad08ad9db1ed280c05bbe1e55"
+  version = "v0.1.23"
 
 [[projects]]
   digest = "1:623090ece42820e4121c5c85a4373b10b922e79f3b8c44caad67a45a50e10054"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,7 +13,7 @@
 
 [[constraint]]
   name = "github.com/openshift-online/uhc-sdk-go"
-  version = "0.1.22"
+  version = "0.1.23"
 
 [[constraint]]
   name = "github.com/spf13/pflag"

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.15"
+const Version = "0.1.16"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fix deprecated issuer: should be _developers.redhat.com_ instead of
  _sso.redhat.com_.