### PR TITLE
Move connection creation to config

### DIFF
--- a/cmd/uhc/cluster/describe/describe.go
+++ b/cmd/uhc/cluster/describe/describe.go
@@ -21,12 +21,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-cli/pkg/util"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	v1 "github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
-
 	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/uhc-cli/pkg/config"
 )
 
 var args struct {
@@ -84,7 +82,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -94,24 +92,8 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Create the connection, and remember to close it:
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/cluster/list/list.go
+++ b/cmd/uhc/cluster/list/list.go
@@ -26,11 +26,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-cli/pkg/util"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	v1 "github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/uhc-cli/pkg/config"
 )
 
 var args struct {
@@ -223,7 +222,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -233,24 +232,8 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Create the connection, and remember to close it:
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/cluster/login/login.go
+++ b/cmd/uhc/cluster/login/login.go
@@ -23,13 +23,11 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-cli/pkg/util"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
-
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
+
+	"github.com/openshift-online/uhc-cli/pkg/config"
 )
 
 var args struct {
@@ -89,7 +87,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -99,24 +97,8 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Create the logger
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Create the connection, and remember to close it:
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/cluster/status/status.go
+++ b/cmd/uhc/cluster/status/status.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-cli/pkg/util"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/uhc-cli/pkg/config"
 )
 
 var args struct {
@@ -65,7 +64,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -75,24 +74,8 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Create the connection, and remember to close it:
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/config/get/get.go
+++ b/cmd/uhc/config/get/get.go
@@ -76,8 +76,6 @@ func run(cmd *cobra.Command, argv []string) {
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.RefreshToken)
 	case "scopes":
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.Scopes)
-	case "token":
-		fmt.Fprintf(os.Stdout, "%s\n", cfg.Token)
 	case "token_url":
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.TokenURL)
 	case "url":

--- a/cmd/uhc/config/set/set.go
+++ b/cmd/uhc/config/set/set.go
@@ -83,8 +83,6 @@ func run(cmd *cobra.Command, argv []string) {
 	case "scopes":
 		fmt.Fprintf(os.Stderr, "Setting scopes is unsupported")
 		os.Exit(1)
-	case "token":
-		cfg.Token = value
 	case "token_url":
 		cfg.TokenURL = value
 	case "url":

--- a/cmd/uhc/delete/cmd.go
+++ b/cmd/uhc/delete/cmd.go
@@ -21,13 +21,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/uhc-cli/pkg/config"
 	"github.com/openshift-online/uhc-cli/pkg/dump"
 	"github.com/openshift-online/uhc-cli/pkg/urls"
-	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
 var args struct {
@@ -90,7 +88,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -101,21 +99,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/get/cmd.go
+++ b/cmd/uhc/get/cmd.go
@@ -21,13 +21,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/uhc-cli/pkg/config"
 	"github.com/openshift-online/uhc-cli/pkg/dump"
 	"github.com/openshift-online/uhc-cli/pkg/urls"
-	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
 var args struct {
@@ -97,7 +95,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -108,21 +106,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/patch/cmd.go
+++ b/cmd/uhc/patch/cmd.go
@@ -22,13 +22,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/uhc-cli/pkg/config"
 	"github.com/openshift-online/uhc-cli/pkg/dump"
 	"github.com/openshift-online/uhc-cli/pkg/urls"
-	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
 var args struct {
@@ -99,7 +97,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -110,21 +108,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/post/cmd.go
+++ b/cmd/uhc/post/cmd.go
@@ -22,13 +22,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/uhc-cli/pkg/config"
 	"github.com/openshift-online/uhc-cli/pkg/dump"
 	"github.com/openshift-online/uhc-cli/pkg/urls"
-	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
 var args struct {
@@ -99,7 +97,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -110,21 +108,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/token/cmd.go
+++ b/cmd/uhc/token/cmd.go
@@ -22,12 +22,10 @@ import (
 	"os"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/uhc-cli/pkg/config"
 	"github.com/openshift-online/uhc-cli/pkg/dump"
-	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
 var args struct {
@@ -117,7 +115,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -128,21 +126,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	logger, err := util.NewLogger(args.debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(args.debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/whoami/cmd.go
+++ b/cmd/uhc/whoami/cmd.go
@@ -21,13 +21,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	amsv1 "github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/uhc-cli/pkg/config"
 	"github.com/openshift-online/uhc-cli/pkg/dump"
-	"github.com/openshift-online/uhc-cli/pkg/util"
 )
 
 var Cmd = &cobra.Command{
@@ -62,7 +60,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := config.Armed(cfg)
+	armed, err := cfg.Armed()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't check if tokens have expired: %v\n", err)
 		os.Exit(1)
@@ -73,21 +71,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	logger, err := util.NewLogger(debug)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't create logger: %v\n", err)
-		os.Exit(1)
-	}
-	connection, err := client.NewConnectionBuilder().
-		Logger(logger).
-		TokenURL(cfg.TokenURL).
-		Client(cfg.ClientID, cfg.ClientSecret).
-		Scopes(cfg.Scopes...).
-		URL(cfg.URL).
-		User(cfg.User, cfg.Password).
-		Tokens(cfg.AccessToken, cfg.RefreshToken).
-		Insecure(cfg.Insecure).
-		Build()
+	connection, err := cfg.Connection(debug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This patch moves the code that creates the connection to the `config`
package, as it will always be created using the configuration stored in
the `Config` type.