### PR TITLE
Make `--debug` global

### DIFF
--- a/cmd/uhc/cluster/cmd.go
+++ b/cmd/uhc/cluster/cmd.go
@@ -27,9 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var args struct {
-	debug bool
-}
 var Cmd = &cobra.Command{
 	Use:   "cluster COMMAND",
 	Short: "Get information about clusters",
@@ -38,13 +35,6 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	Cmd.AddCommand(list.Cmd)
 	Cmd.AddCommand(status.Cmd)
 	Cmd.AddCommand(describe.Cmd)

--- a/cmd/uhc/cluster/describe/describe.go
+++ b/cmd/uhc/cluster/describe/describe.go
@@ -28,7 +28,6 @@ import (
 )
 
 var args struct {
-	debug  bool
 	json   bool
 	output bool
 }
@@ -43,12 +42,6 @@ var Cmd = &cobra.Command{
 func init() {
 	// Add flags to rootCmd:
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	flags.BoolVar(
 		&args.output,
 		"output",
@@ -93,7 +86,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/cluster/list/list.go
+++ b/cmd/uhc/cluster/list/list.go
@@ -34,7 +34,6 @@ import (
 
 var args struct {
 	parameter []string
-	debug     bool
 	managed   bool
 	step      bool
 	columns   string
@@ -162,12 +161,6 @@ func findMapValue(data map[string]interface{}, key string) (string, bool) {
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	flags.StringArrayVar(
 		&args.parameter,
 		"parameter",
@@ -233,7 +226,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/cluster/login/login.go
+++ b/cmd/uhc/cluster/login/login.go
@@ -31,8 +31,7 @@ import (
 )
 
 var args struct {
-	debug bool
-	user  string
+	user string
 }
 
 const ClustersPageSize = 50
@@ -48,12 +47,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	flags.StringVarP(
 		&args.user,
 		"username",
@@ -98,7 +91,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/cluster/status/status.go
+++ b/cmd/uhc/cluster/status/status.go
@@ -25,10 +25,6 @@ import (
 	"github.com/openshift-online/uhc-cli/pkg/config"
 )
 
-var args struct {
-	debug bool
-}
-
 var Cmd = &cobra.Command{
 	Use:   "status CLUSTERID",
 	Short: "Status of a cluster",
@@ -36,15 +32,6 @@ var Cmd = &cobra.Command{
 	Run:   run,
 }
 
-func init() {
-	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
-}
 func run(cmd *cobra.Command, argv []string) {
 
 	if len(argv) != 1 {
@@ -75,7 +62,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/config/cmd.go
+++ b/cmd/uhc/config/cmd.go
@@ -23,23 +23,12 @@ import (
 	"github.com/openshift-online/uhc-cli/cmd/uhc/config/set"
 )
 
-var args struct {
-	debug bool
-}
-
 var Cmd = &cobra.Command{
 	Use:   "config COMMAND VARIABLE",
 	Short: "get or set configuration variables",
 }
 
 func init() {
-	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	Cmd.AddCommand(get.Cmd)
 	Cmd.AddCommand(set.Cmd)
 }

--- a/cmd/uhc/delete/cmd.go
+++ b/cmd/uhc/delete/cmd.go
@@ -29,7 +29,6 @@ import (
 )
 
 var args struct {
-	debug     bool
 	parameter []string
 	header    []string
 }
@@ -43,12 +42,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	flags.StringArrayVar(
 		&args.parameter,
 		"parameter",
@@ -99,7 +92,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/get/cmd.go
+++ b/cmd/uhc/get/cmd.go
@@ -31,7 +31,6 @@ import (
 var args struct {
 	parameter []string
 	header    []string
-	debug     bool
 	single    bool
 }
 
@@ -44,12 +43,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	flags.StringArrayVar(
 		&args.parameter,
 		"parameter",
@@ -106,7 +99,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/login/cmd.go
+++ b/cmd/uhc/login/cmd.go
@@ -55,7 +55,6 @@ var args struct {
 	user         string
 	password     string
 	insecure     bool
-	debug        bool
 	persistent   bool
 }
 
@@ -133,12 +132,6 @@ func init() {
 		false,
 		"Enables insecure communication with the server. This disables verification of TLS "+
 			"certificates and host names.",
-	)
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
 	)
 	flags.BoolVar(
 		&args.persistent,
@@ -284,7 +277,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create a connection and get the token to verify that the crendentials are correct:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/logout/cmd.go
+++ b/cmd/uhc/logout/cmd.go
@@ -25,25 +25,11 @@ import (
 	"github.com/openshift-online/uhc-cli/pkg/config"
 )
 
-var args struct {
-	debug bool
-}
-
 var Cmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Log out",
 	Long:  "Log out, removing the configuration file.",
 	Run:   run,
-}
-
-func init() {
-	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 }
 
 func run(cmd *cobra.Command, argv []string) {

--- a/cmd/uhc/main.go
+++ b/cmd/uhc/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift-online/uhc-cli/cmd/uhc/token"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/version"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/whoami"
+	"github.com/openshift-online/uhc-cli/pkg/debug"
 )
 
 var root = &cobra.Command{
@@ -55,6 +56,10 @@ func init() {
 	// Register the options that are managed by the 'flag' package, so that they will also be parsed
 	// by the 'pflag' package:
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	// Add the command line flags:
+	flags := root.PersistentFlags()
+	debug.AddFlag(flags)
 
 	// Register the subcommands:
 	root.AddCommand(delete.Cmd)

--- a/cmd/uhc/patch/cmd.go
+++ b/cmd/uhc/patch/cmd.go
@@ -30,7 +30,6 @@ import (
 )
 
 var args struct {
-	debug     bool
 	parameter []string
 	header    []string
 	body      string
@@ -45,12 +44,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	flags.StringArrayVar(
 		&args.parameter,
 		"parameter",
@@ -108,7 +101,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/post/cmd.go
+++ b/cmd/uhc/post/cmd.go
@@ -30,7 +30,6 @@ import (
 )
 
 var args struct {
-	debug     bool
 	parameter []string
 	header    []string
 	body      string
@@ -45,12 +44,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
 	flags.StringSliceVar(
 		&args.parameter,
 		"parameter",
@@ -108,7 +101,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/token/cmd.go
+++ b/cmd/uhc/token/cmd.go
@@ -29,7 +29,6 @@ import (
 )
 
 var args struct {
-	debug     bool
 	header    bool
 	payload   bool
 	signature bool
@@ -68,12 +67,6 @@ func init() {
 		"refresh",
 		false,
 		"Print the refresh token instead of the access token.",
-	)
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
 	)
 }
 
@@ -126,7 +119,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	connection, err := cfg.Connection(args.debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/cmd/uhc/whoami/cmd.go
+++ b/cmd/uhc/whoami/cmd.go
@@ -35,18 +35,6 @@ var Cmd = &cobra.Command{
 	Run:   run,
 }
 
-var debug bool
-
-func init() {
-	flags := Cmd.Flags()
-	flags.BoolVar(
-		&debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
-}
-
 func run(cmd *cobra.Command, argv []string) {
 	// Load the configuration file:
 	cfg, err := config.Load()
@@ -71,7 +59,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Create the connection:
-	connection, err := cfg.Connection(debug)
+	connection, err := cfg.Connection()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't create connection: %v\n", err)
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,9 +28,10 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/golang/glog"
 	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 
-	"github.com/openshift-online/uhc-cli/pkg/util"
+	"github.com/openshift-online/uhc-cli/pkg/debug"
 )
 
 // Config is the type used to store the configuration of the client.
@@ -164,9 +165,17 @@ func (c *Config) Armed() (armed bool, err error) {
 }
 
 // Connection creates a connection using this configuration.
-func (c *Config) Connection(debug bool) (connection *client.Connection, err error) {
+func (c *Config) Connection() (connection *client.Connection, err error) {
 	// Create the logger:
-	logger, err := util.NewLogger(debug)
+	level := glog.Level(1)
+	if debug.Enabled() {
+		level = glog.Level(0)
+	}
+	logger, err := client.NewGlogLoggerBuilder().
+		DebugV(level).
+		InfoV(level).
+		WarnV(level).
+		Build()
 	if err != nil {
 		return
 	}

--- a/pkg/debug/flag.go
+++ b/pkg/debug/flag.go
@@ -14,28 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+// This file contains functions used to implement the '--debug' command line option.
+
+package debug
 
 import (
-	"github.com/golang/glog"
-
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+	"github.com/spf13/pflag"
 )
 
-// NewLogger creates a new logger with the debug level enabled according to the given value.
-func NewLogger(debug bool) (logger client.Logger, err error) {
-	debugV := glog.Level(1)
-	infoV := glog.Level(1)
-	warnV := glog.Level(1)
-	if debug {
-		debugV = glog.Level(0)
-		infoV = glog.Level(0)
-		warnV = glog.Level(0)
-	}
-	logger, err = client.NewGlogLoggerBuilder().
-		DebugV(debugV).
-		InfoV(infoV).
-		WarnV(warnV).
-		Build()
-	return
+// AddFlag adds the debug flag to the given set of command line flags.
+func AddFlag(flags *pflag.FlagSet) {
+	flags.BoolVar(
+		&enabled,
+		"debug",
+		false,
+		"Enable debug mode.",
+	)
 }
+
+// Enabled retursn a boolean flag that indicates if the debug mode is enabled.
+func Enabled() bool {
+	return enabled
+}
+
+// enabled is a boolean flag that indicates that the debug mode is enabled.
+var enabled bool


### PR DESCRIPTION
This patch changes the tool so that the `--debug` command line flag
applies to all the commands in the same way, and so that it isn't
necessary to define it multiple times.