### PR TITLE
Move `--parameter` and `--header` to flags package

### DIFF
--- a/cmd/uhc/delete/cmd.go
+++ b/cmd/uhc/delete/cmd.go
@@ -19,12 +19,12 @@ package delete
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/uhc-cli/pkg/config"
 	"github.com/openshift-online/uhc-cli/pkg/dump"
+	"github.com/openshift-online/uhc-cli/pkg/flags"
 	"github.com/openshift-online/uhc-cli/pkg/urls"
 )
 
@@ -41,25 +41,9 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	flags := Cmd.Flags()
-	flags.StringArrayVar(
-		&args.parameter,
-		"parameter",
-		nil,
-		"Query parameters to add to the request. The value must be the name of the "+
-			"parameter, followed by an optional equals sign and then the value "+
-			"of the parameter. Can be used multiple times to specify multiple "+
-			"parameters or multiple values for the same parameter.",
-	)
-	flags.StringArrayVar(
-		&args.header,
-		"header",
-		nil,
-		"Headers to add to the request. The value must be the name of the header "+
-			"followed by an optional equals sign and then the value of the "+
-			"header. Can be used multiple times to specify multiple headers "+
-			"or multiple values for the same header.",
-	)
+	fs := Cmd.Flags()
+	flags.AddParameterFlag(fs, &args.parameter)
+	flags.AddHeaderFlag(fs, &args.header)
 }
 
 func run(cmd *cobra.Command, argv []string) {
@@ -100,32 +84,8 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Create and populate the request:
 	request := connection.Delete().Path(path)
-	for _, parameter := range args.parameter {
-		var name string
-		var value string
-		position := strings.Index(parameter, "=")
-		if position != -1 {
-			name = parameter[:position]
-			value = parameter[position+1:]
-		} else {
-			name = parameter
-			value = ""
-		}
-		request.Parameter(name, value)
-	}
-	for _, header := range args.header {
-		var name string
-		var value string
-		position := strings.Index(header, "=")
-		if position != -1 {
-			name = header[:position]
-			value = header[position+1:]
-		} else {
-			name = header
-			value = ""
-		}
-		request.Header(name, value)
-	}
+	flags.ApplyParameterFlag(request, args.parameter)
+	flags.ApplyHeaderFlag(request, args.header)
 
 	// Send the request:
 	response, err := request.Send()

--- a/cmd/uhc/main.go
+++ b/cmd/uhc/main.go
@@ -37,7 +37,7 @@ import (
 	"github.com/openshift-online/uhc-cli/cmd/uhc/token"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/version"
 	"github.com/openshift-online/uhc-cli/cmd/uhc/whoami"
-	"github.com/openshift-online/uhc-cli/pkg/debug"
+	"github.com/openshift-online/uhc-cli/pkg/flags"
 )
 
 var root = &cobra.Command{
@@ -58,8 +58,8 @@ func init() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	// Add the command line flags:
-	flags := root.PersistentFlags()
-	debug.AddFlag(flags)
+	fs := root.PersistentFlags()
+	flags.AddDebugFlag(fs)
 
 	// Register the subcommands:
 	root.AddCommand(delete.Cmd)

--- a/cmd/uhc/post/cmd.go
+++ b/cmd/uhc/post/cmd.go
@@ -18,14 +18,13 @@ package post
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/uhc-cli/pkg/config"
 	"github.com/openshift-online/uhc-cli/pkg/dump"
+	"github.com/openshift-online/uhc-cli/pkg/flags"
 	"github.com/openshift-online/uhc-cli/pkg/urls"
 )
 
@@ -43,32 +42,10 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	flags := Cmd.Flags()
-	flags.StringSliceVar(
-		&args.parameter,
-		"parameter",
-		nil,
-		"Query parameters to add to the request. The value must be the name of the "+
-			"parameter, followed by an optional equals sign and then the value "+
-			"of the parameter. Can be used multiple times to specify multiple "+
-			"parameters or multiple values for the same parameter.",
-	)
-	flags.StringSliceVar(
-		&args.header,
-		"header",
-		nil,
-		"Headers to add to the request. The value must be the name of the header "+
-			"followed by an optional equals sign and then the value of the "+
-			"header. Can be used multiple times to specify multiple headers "+
-			"or multiple values for the same header.",
-	)
-	flags.StringVar(
-		&args.body,
-		"body",
-		"",
-		"Name fo the file containing the request body. If this isn't given then "+
-			"the body will be taken from the standard input.",
-	)
+	fs := Cmd.Flags()
+	flags.AddParameterFlag(fs, &args.parameter)
+	flags.AddHeaderFlag(fs, &args.header)
+	flags.AddBodyFlag(fs, &args.body)
 }
 
 func run(cmd *cobra.Command, argv []string) {
@@ -109,43 +86,13 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Create and populate the request:
 	request := connection.Post().Path(path)
-	for _, parameter := range args.parameter {
-		var name string
-		var value string
-		position := strings.Index(parameter, "=")
-		if position != -1 {
-			name = parameter[:position]
-			value = parameter[position+1:]
-		} else {
-			name = parameter
-			value = ""
-		}
-		request.Parameter(name, value)
-	}
-	for _, header := range args.header {
-		var name string
-		var value string
-		position := strings.Index(header, "=")
-		if position != -1 {
-			name = header[:position]
-			value = header[position+1:]
-		} else {
-			name = header
-			value = ""
-		}
-		request.Header(name, value)
-	}
-	var body []byte
-	if args.body != "" {
-		body, err = ioutil.ReadFile(args.body)
-	} else {
-		body, err = ioutil.ReadAll(os.Stdin)
-	}
+	flags.ApplyParameterFlag(request, args.parameter)
+	flags.ApplyHeaderFlag(request, args.parameter)
+	err = flags.ApplyBodyFlag(request, args.body)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't read body: %v\n", err)
 		os.Exit(1)
 	}
-	request.Bytes(body)
 
 	// Send the request:
 	response, err := request.Send()
@@ -154,7 +101,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 	status := response.Status()
-	body = response.Bytes()
+	body := response.Bytes()
 	if status < 400 {
 		err = dump.Pretty(os.Stdout, body)
 	} else {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -1,0 +1,129 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains functions that add common flags to the command line.
+
+package flags
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+	"github.com/spf13/pflag"
+
+	"github.com/openshift-online/uhc-cli/pkg/debug"
+)
+
+// AddDebugFlag adds the '--debug' flag to the given set of command line flags.
+func AddDebugFlag(fs *pflag.FlagSet) {
+	debug.AddFlag(fs)
+}
+
+// AddParameterFlag adds the '--parameter' flag to the given set of command line flags.
+func AddParameterFlag(fs *pflag.FlagSet, values *[]string) {
+	fs.StringArrayVar(
+		values,
+		"parameter",
+		nil,
+		"Query parameters to add to the request. The value must be the name of the "+
+			"parameter, followed by an optional equals sign and then the value "+
+			"of the parameter. Can be used multiple times to specify multiple "+
+			"parameters or multiple values for the same parameter.",
+	)
+}
+
+// AddHeaderFlag adds the '--header' flag to the given set of command line flags.
+func AddHeaderFlag(fs *pflag.FlagSet, values *[]string) {
+	fs.StringArrayVar(
+		values,
+		"header",
+		nil,
+		"Headers to add to the request. The value must be the name of the header "+
+			"followed by an optional equals sign and then the value of the "+
+			"header. Can be used multiple times to specify multiple headers "+
+			"or multiple values for the same header.",
+	)
+}
+
+// AddBodyFlag adds the '--body' flag to the given set of command line flags.
+func AddBodyFlag(fs *pflag.FlagSet, value *string) {
+	fs.StringVar(
+		value,
+		"body",
+		"",
+		"Name fo the file containing the request body. If this isn't given then "+
+			"the body will be taken from the standard input.",
+	)
+}
+
+// ApplyParameterFlag applies the value of the '--parameter' command line flag to the given
+// request.
+func ApplyParameterFlag(request interface{}, values []string) {
+	applyNVFlag(request, "Parameter", values)
+}
+
+// ApplyHeaderFlag applies the value of the '--header' command line flag to the given request.
+func ApplyHeaderFlag(request interface{}, values []string) {
+	applyNVFlag(request, "Header", values)
+}
+
+// applyNVFlag finds the method with the given name in a request and calls it to set a collection of
+// name value pairs.
+func applyNVFlag(request interface{}, method string, values []string) {
+	// Find the method:
+	callable := reflect.ValueOf(request).MethodByName(method)
+	if !callable.IsValid() {
+		return
+	}
+
+	// Split the values into name value pairs and call the method for each one:
+	for _, value := range values {
+		var name string
+		position := strings.Index(value, "=")
+		if position != -1 {
+			name = value[:position]
+			value = value[position+1:]
+		} else {
+			name = value
+			value = ""
+		}
+		args := []reflect.Value{
+			reflect.ValueOf(name),
+			reflect.ValueOf(value),
+		}
+		callable.Call(args)
+	}
+}
+
+// ApplyBodyFlag applies the value of the '--body' command line flag to the given request.
+func ApplyBodyFlag(request *client.Request, value string) error {
+	var body []byte
+	var err error
+	if value != "" {
+		// #nosec G304
+		body, err = ioutil.ReadFile(value)
+	} else {
+		body, err = ioutil.ReadAll(os.Stdin)
+	}
+	if err != nil {
+		return err
+	}
+	request.Bytes(body)
+	return nil
+}


### PR DESCRIPTION
This patch moves the code that implements the `--parameter` and
`--header` command line flags to a new `flags` package.