### PR TITLE
Print roles of current user with 'uhc account status'

### DIFF
--- a/cmd/uhc/account/status/cmd.go
+++ b/cmd/uhc/account/status/cmd.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/uhc-cli/cmd/uhc/account/users"
+	acc_util "github.com/openshift-online/uhc-cli/pkg/account"
 	"github.com/openshift-online/uhc-cli/pkg/config"
 )
 
@@ -92,6 +92,7 @@ func run(cmd *cobra.Command, argv []string) {
 	currAccount := response.Body()
 	fmt.Println(fmt.Sprintf("%s on %s", currAccount.Username(), cfg.URL))
 
-	roleSlice := users.GetRolesFromUser(currAccount, connection)
+	// Display roles currently assigned to the user
+	roleSlice := acc_util.GetRolesFromUser(currAccount, connection)
 	fmt.Printf("Roles: %v\n", roleSlice)
 }

--- a/cmd/uhc/account/status/cmd.go
+++ b/cmd/uhc/account/status/cmd.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/uhc-cli/cmd/uhc/account/users"
 	"github.com/openshift-online/uhc-cli/pkg/config"
 )
 
@@ -91,4 +92,6 @@ func run(cmd *cobra.Command, argv []string) {
 	currAccount := response.Body()
 	fmt.Println(fmt.Sprintf("%s on %s", currAccount.Username(), cfg.URL))
 
+	roleSlice := users.GetRolesFromUser(currAccount, connection)
+	fmt.Printf("Roles: %v\n", roleSlice)
 }

--- a/cmd/uhc/account/users/cmd.go
+++ b/cmd/uhc/account/users/cmd.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	acc_util "github.com/openshift-online/uhc-cli/pkg/account"
 	"github.com/openshift-online/uhc-cli/pkg/config"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client"
 	amv1 "github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1"
 )
 
@@ -136,7 +136,7 @@ func run(cmd *cobra.Command, argv []string) {
 			if args.org == account.Organization().ID() {
 				username := stringPad(account.Username(), namePad)
 				userID := stringPad(account.ID(), namePad)
-				accountRoleList := GetRolesFromUser(account, connection)
+				accountRoleList := acc_util.GetRolesFromUser(account, connection)
 				fmt.Println(username, userID, printArray(accountRoleList))
 			}
 			return true
@@ -149,56 +149,6 @@ func run(cmd *cobra.Command, argv []string) {
 		pageIndex++
 	}
 
-}
-
-// GetRolesFromUser gets all roles a specific user possesses.
-func GetRolesFromUser(account *amv1.Account, conn *client.Connection) []string {
-
-	pageIndex := 1
-	var roles []string
-
-	// Get all roles in each role page:
-	for {
-		rolesList := conn.AccountsMgmt().V1().RoleBindings().List().Page(pageIndex)
-		// Format search request:
-		searchRequest := ""
-		searchRequest = fmt.Sprintf("account_id='%s'", account.ID())
-		// Add parameter to search for role with matching user id:
-		rolesList.Parameter("search", searchRequest)
-		// Get response:
-		response, err := rolesList.Send()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Can't retrieve roles: %v\n", err)
-			os.Exit(1)
-		}
-		// Loop through roles and save their ids
-		// iff it is not in the list yet:
-		response.Items().Each(func(item *amv1.RoleBinding) bool {
-			if !stringInList(roles, item.Role().ID()) {
-				roles = append(roles, item.Role().ID())
-			}
-			return true
-		})
-
-		// Break
-		if response.Size() < 100 {
-			break
-		}
-
-		pageIndex++
-	}
-	return roles
-}
-
-// stringInList returns a bool signifying whether
-// a string is in a string array.
-func stringInList(strArr []string, key string) bool {
-	for _, str := range strArr {
-		if str == key {
-			return true
-		}
-	}
-	return false
 }
 
 // stringPad will add whitespace or clip a string

--- a/cmd/uhc/account/users/cmd.go
+++ b/cmd/uhc/account/users/cmd.go
@@ -136,7 +136,7 @@ func run(cmd *cobra.Command, argv []string) {
 			if args.org == account.Organization().ID() {
 				username := stringPad(account.Username(), namePad)
 				userID := stringPad(account.ID(), namePad)
-				accountRoleList := getRolesFromUser(account, connection)
+				accountRoleList := GetRolesFromUser(account, connection)
 				fmt.Println(username, userID, printArray(accountRoleList))
 			}
 			return true
@@ -151,8 +151,8 @@ func run(cmd *cobra.Command, argv []string) {
 
 }
 
-// getRolesFromUser gets all roles a specific user possesses.
-func getRolesFromUser(account *amv1.Account, conn *client.Connection) []string {
+// GetRolesFromUser gets all roles a specific user possesses.
+func GetRolesFromUser(account *amv1.Account, conn *client.Connection) []string {
 
 	pageIndex := 1
 	var roles []string

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package account
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+	amv1 "github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1"
+)
+
+// GetRolesFromUser gets all roles a specific user possesses.
+func GetRolesFromUser(account *amv1.Account, conn *client.Connection) []string {
+
+	pageIndex := 1
+	var roles []string
+
+	// Get all roles in each role page:
+	for {
+		rolesList := conn.AccountsMgmt().V1().RoleBindings().List().Page(pageIndex)
+		// Format search request:
+		searchRequest := ""
+		searchRequest = fmt.Sprintf("account_id='%s'", account.ID())
+		// Add parameter to search for role with matching user id:
+		rolesList.Parameter("search", searchRequest)
+		// Get response:
+		response, err := rolesList.Send()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Can't retrieve roles: %v\n", err)
+			os.Exit(1)
+		}
+		// Loop through roles and save their ids
+		// iff it is not in the list yet:
+		response.Items().Each(func(item *amv1.RoleBinding) bool {
+			if !stringInList(roles, item.Role().ID()) {
+				roles = append(roles, item.Role().ID())
+			}
+			return true
+		})
+
+		// Break
+		if response.Size() < 100 {
+			break
+		}
+
+		pageIndex++
+	}
+	return roles
+}
+
+// stringInList returns a bool signifying whether
+// a string is in a string array.
+func stringInList(strArr []string, key string) bool {
+	for _, str := range strArr {
+		if str == key {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
As per SREP-1860, uhc account status now returns:

\<user\> on \<server\>
Roles: [\<role1\> \<role2\> \<role3\>]