### PR TITLE
Use a config file for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+run:
+  deadline: 15m
+  issues-exit-code: 1
+  modules-download-mode: readonly
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - gas
+    - goconst
+    - gocyclo
+    - gofmt
+    - golint
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - megacheck
+    - misspell
+    - structcheck
+    - unconvert
+    - varcheck

--- a/Makefile
+++ b/Makefile
@@ -38,27 +38,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	golangci-lint run \
-		--no-config \
-		--issues-exit-code=1 \
-		--deadline=15m \
-		--disable-all \
-		--enable=deadcode \
-		--enable=gas \
-		--enable=goconst \
-		--enable=gocyclo \
-		--enable=gofmt \
-		--enable=golint \
-		--enable=ineffassign \
-		--enable=interfacer \
-		--enable=lll \
-		--enable=maligned \
-		--enable=megacheck \
-		--enable=misspell \
-		--enable=structcheck \
-		--enable=unconvert \
-		--enable=varcheck \
-		$(NULL)
+	golangci-lint run
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Use a config files for golangci-lint instead of using command line flags in make. This is effectively a noop as I've just copied the same flags that are currently in the Makefile into the config file.