### PR TITLE
increase column padding to avoid truncating names and versions

### DIFF
--- a/cmd/uhc/cluster/list/list.go
+++ b/cmd/uhc/cluster/list/list.go
@@ -129,7 +129,7 @@ func run(cmd *cobra.Command, argv []string) {
 	colUpper := strings.ToUpper(args.columns)
 	colUpper = strings.Replace(colUpper, ".", " ", -1)
 	columnNames := strings.Split(colUpper, ",")
-	paddingByColumn := []int{35, 25, 70, 25, 15}
+	paddingByColumn := []int{35, 60, 70, 60, 15}
 	if args.columns != "id,name,api.url,version.id,region.id" {
 		paddingByColumn = []int{args.padding}
 	}


### PR DESCRIPTION
Before
```
$ uhc cluster list                                                                                                                                                                                               
ID                                 NAME                     API URL                                                               VERSION ID               REGION ID                                                                                                           
                                                                                                                                                                                                                                                                               
17fko08v603mrjr575d80gp721renuom   je-uhc-post-test-2       NONE                                                                  openshift-v4.2.0-0.nigh  us-east-1                                                                                                           
17fkv5r61l8ft0sa38pmnd4j8p5iqqfe   ci-cluster-v4-1-0-0-nig  NONE                                                                  openshift-v4.1.0-0.nigh  us-east-1
```

After
```
$ ./uhc cluster list
ID                                 NAME                                                        API URL                                                               VERSION ID                                                  REGION ID      

17fko08v603mrjr575d80gp721renuom   je-uhc-post-test-2                                          NONE                                                                  openshift-v4.2.0-0.nightly-2019-08-08-103722                us-east-1      
17fkv5r61l8ft0sa38pmnd4j8p5iqqfe   ci-cluster-v4-1-0-0-nightly-2019-08-11-140905-vr7           https://api.ci-cluster-v4-1.g4b9.i1.devshift.org:6443                 openshift-v4.1.0-0.nightly-2019-08-11-140905                us-east-1
```