### PR TITLE
Release 0.1.19

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the
 `uhc` command line tool.
 
+== 0.1.19 Aug 15 2019
+
+- Fixed issue https://github.com/openshift-online/uhc-cli/pull/62[#62]: the
+  `--url` option of the `login` command should not be mandatory.
+
 == 0.1.18 Aug 14 2019
 
 - Improvements in the `cluster list` command, including increasing the size of

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.18"
+const Version = "0.1.19"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fixed issue https://github.com/openshift-online/uhc-cli/pull/62[#62]: the
  `--url` option of the `login` command should not be mandatory.